### PR TITLE
Prevent dangerous constructor instantiation

### DIFF
--- a/README.md
+++ b/README.md
@@ -114,8 +114,14 @@ Option keys missing from `options` are left unchanged.
 Register an error constructor for serialization and deserialization with
 option overrides.
 
-The error name can be passed in `options.name`, otherwise it is inferred by
-instantiating the constructor with no arguments.
+The error name will be taken from the first of these that is set:
+
+1. `options.name`
+2. `constructor.prototype.name`, if it is not 'Error'
+3. `constructor.name`
+4. `new constructor().name`
+
+Note that in the last case, the constructor is instantiated with no arguments.
 
 All [built-in error classes][builtins] are automatically registered with
 no option overrides.

--- a/index.js
+++ b/index.js
@@ -19,11 +19,19 @@ exports.setDefaults = function(options) {
 var errors = {};
 
 // Register an error constructor for serialization and deserialization with
-// option overrides. Name can be specified in options, otherwise name is taken
-// from instantiating the constructor with no arguments.
+// option overrides. Name can be specified in options, otherwise it will be
+// taken from the prototype's name property (if it is not set to Error), the
+// constructor's name property, or the name property of an instance of the
+// constructor.
 exports.register = function(constructor, options) {
   options = options || {};
-  var name = options.name || new constructor().name;
+  var prototypeName = constructor.prototype.name !== 'Error'
+    ? constructor.prototype.name
+    : null;
+  var name = options.name
+    || prototypeName
+    || constructor.name
+    || new constructor().name;
   errors[name] = { constructor: constructor, options: options };
 };
 

--- a/test/register-test.js
+++ b/test/register-test.js
@@ -1,5 +1,7 @@
 'use strict';
 
+var assert = require('assert');
+
 var SuperError = require('super-error');
 var Errio = require('..');
 


### PR DESCRIPTION
Try to get the name from safer sources first.
