### PR TITLE
Error.captureStackTrace is not a function outside of v8/Chrome

### DIFF
--- a/index.js
+++ b/index.js
@@ -174,7 +174,7 @@ exports.fromObject = function(object, callOptions) {
 
   // Capture a new stack trace such that the first trace line is the caller of
   // fromObject.
-  if (!error.stack) {
+  if (!error.stack && Error.captureStackTrace) {
     Error.captureStackTrace(error, exports.fromObject);
   }
 


### PR DESCRIPTION
If used in Safari, Firefox, or other non-v8-based environments, `Error.captureStackTrace` doesn't exist. This patch wraps the reference in a guard clause to allow better interoperability.